### PR TITLE
Extend config file

### DIFF
--- a/monitor/config.go
+++ b/monitor/config.go
@@ -6,6 +6,32 @@ import (
 	"time"
 )
 
+type ConsulConfig struct {
+	Address     string   `json:"address"`
+	ServiceName string   `json:"service_name"`
+	Tags        []string `json:"tags"`
+}
+
+func DefaultConsulConfig() *ConsulConfig {
+	return &ConsulConfig{
+		Address:     "http://127.0.0.1:8500",
+		ServiceName: "pool",
+		Tags:        []string{"pool", "parity"},
+	}
+}
+
+func (c *ConsulConfig) Merge(c1 *ConsulConfig) {
+	if c1.Address != "" {
+		c.Address = c1.Address
+	}
+	if c1.ServiceName != "" {
+		c.ServiceName = c1.ServiceName
+	}
+	if len(c1.Tags) != 0 {
+		c.Tags = c1.Tags
+	}
+}
+
 type Config struct {
 	LogOutput   io.Writer
 	BindAddr    string `json:"bind"`
@@ -15,8 +41,7 @@ type Config struct {
 	RPCInterval time.Duration
 
 	// Consul config
-	ConsulAddress     string
-	ConsulServiceName string
+	ConsulConfig *ConsulConfig `json:"consul"`
 
 	// Sync threashold
 	SyncThreshold int
@@ -24,15 +49,14 @@ type Config struct {
 
 func DefaultConfig() *Config {
 	c := &Config{
-		LogOutput:         os.Stderr,
-		BindAddr:          "127.0.0.1",
-		BindPort:          4546,
-		NodeName:          "parity",
-		Endpoint:          "http://127.0.0.1:8545",
-		RPCInterval:       time.Duration(5) * time.Second,
-		ConsulAddress:     "http://127.0.0.1:8500",
-		ConsulServiceName: "pool",
-		SyncThreshold:     5,
+		LogOutput:     os.Stderr,
+		BindAddr:      "127.0.0.1",
+		BindPort:      4546,
+		NodeName:      "parity",
+		Endpoint:      "http://127.0.0.1:8545",
+		ConsulConfig:  DefaultConsulConfig(),
+		RPCInterval:   time.Duration(5) * time.Second,
+		SyncThreshold: 5,
 	}
 
 	if hostname, err := os.Hostname(); err == nil {
@@ -40,4 +64,26 @@ func DefaultConfig() *Config {
 	}
 
 	return c
+}
+
+func (c *Config) Merge(c1 *Config) {
+	if c1.BindAddr != "" {
+		c.BindAddr = c1.BindAddr
+	}
+	if c1.BindPort != 0 {
+		c.BindPort = c1.BindPort
+	}
+	if c1.NodeName != "" {
+		c.NodeName = c1.NodeName
+	}
+	if c1.Endpoint != "" {
+		c.Endpoint = c1.Endpoint
+	}
+	if c1.SyncThreshold != 0 {
+		c.SyncThreshold = c1.SyncThreshold
+	}
+
+	if c1.ConsulConfig != nil {
+		c.ConsulConfig.Merge(c1.ConsulConfig)
+	}
 }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -162,10 +162,10 @@ func (m *Monitor) setupConsulImpl() error {
 
 	service := &consulapi.AgentServiceRegistration{
 		ID:      serviceID,
-		Name:    m.config.ConsulServiceName,
+		Name:    m.config.ConsulConfig.ServiceName,
 		Port:    m.config.BindPort,
 		Address: address,
-		Tags:    []string{"pool", "parity", m.chain},
+		Tags:    m.config.ConsulConfig.Tags,
 		Check: &consulapi.AgentServiceCheck{
 			HTTP:     fmt.Sprintf("%s/synced", address),
 			Interval: "1s",
@@ -173,7 +173,10 @@ func (m *Monitor) setupConsulImpl() error {
 		},
 	}
 
-	client, err := consulapi.NewClient(consulapi.DefaultConfig())
+	consulConfig := consulapi.DefaultConfig()
+	consulConfig.Address = m.config.ConsulConfig.Address
+
+	client, err := consulapi.NewClient(consulConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Added

The config file now has a field for consul configuration:

```
{
    "endpoint": "http://localhost:8545",
    "port": 4000,
    "consul": {
        "tags": ["one"],
        "service_name": "xx"
    }
}
```